### PR TITLE
Add Navigator 1.0 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `lib/` holds the public API (`unrouter.dart`) and platform helpers like `browser.dart`; implementation details live in `lib/src/`.
+- `test/` contains Flutter tests (e.g., `*_test.dart` and `test/history/` for history behavior).
+- `example/` is a runnable Flutter app that demonstrates package usage.
+- `build/` is generated output (do not edit by hand).
+- `pubspec.yaml`, `analysis_options.yaml`, and `CHANGELOG.md` capture package metadata, lint rules, and release notes.
+
+## Build, Test, and Development Commands
+- `flutter pub get` installs dependencies.
+- `flutter analyze` runs the analyzer with `flutter_lints`.
+- `dart format .` applies standard Dart formatting (2-space indentation).
+- `flutter test` runs the full test suite in `test/`.
+- `cd example && flutter run` runs the sample app (use `-d chrome` for web).
+
+## Coding Style & Naming Conventions
+- Use the Dart formatter; avoid manual alignment or custom indentation.
+- Follow `flutter_lints` as configured in `analysis_options.yaml`.
+- Naming: `UpperCamelCase` for types, `lowerCamelCase` for variables/functions, and `snake_case.dart` for files.
+- Keep the public surface in `lib/` lean; place internals under `lib/src/`.
+
+## Testing Guidelines
+- Tests use `flutter_test`; name files `*_test.dart`.
+- Prefer focused unit tests and cover navigation/history edge cases.
+- Run a single test file with `flutter test test/navigation_test.dart`.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short, imperative, sentence case (e.g., “Add Link widget for declarative navigation (#9)”, “Bump version to 0.2.0”).
+- PRs should include a concise description, rationale, and testing notes; keep diffs focused.
+- Include screenshots/recordings for UI changes in `example/` when applicable.
+- If changes affect public API or behavior, update `CHANGELOG.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.3.0-wip
+
+### Features
+
+- **Navigator 1.0 compatibility**: added `enableNavigator1` (default `true`) so APIs like `showDialog`, `showModalBottomSheet`, `showMenu`, and `Navigator.push/pop` work when using `Unrouter`.
+- **Example updates**: the example app now demonstrates Navigator 1.0 APIs alongside existing routing patterns.
+
+### Improvements
+
+- `popRoute` now delegates to the embedded Navigator first (when enabled) before falling back to history navigation.
+
+### Testing
+
+- Added comprehensive widget tests covering Navigator 1.0 overlays, push/pop/popUntil, and nested Navigator behavior.
+
 ## 0.2.0
 
 ### Breaking Changes

--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,13 @@
-# example
+# Example App
 
-A new Flutter project.
+This example demonstrates Unrouter's hybrid routing plus Navigator 1.0
+compatibility. The Home screen includes buttons for `showDialog`,
+`showModalBottomSheet`, `showMenu`, and `Navigator.push` to show that these
+APIs work when `enableNavigator1` is enabled (default).
 
-## Getting Started
+## Running
 
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```sh
+flutter pub get
+flutter run -d chrome
+```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ void main() {
 // Declarative routes can use Routes widget internally for progressive routing
 final router = Unrouter(
   strategy: .browser,
+  enableNavigator1: true,
   routes: const [
     Inlet(factory: Home.new),
     Inlet(path: 'about', factory: About.new),
@@ -67,99 +68,146 @@ class Home extends StatelessWidget {
         title: const Text('Home'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.home, size: 80, color: Colors.deepPurple),
-            const SizedBox(height: 24),
-            const Text(
-              'Welcome to Unrouter Example',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 32),
-            const Text(
-              'Imperative Navigation (using buttons)',
-              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
-            ),
-            const SizedBox(height: 16),
-            _buildNavButton(
-              context,
-              'About',
-              Icons.info,
-              Colors.blue,
-              () => context.navigate(.parse('/about')),
-            ),
-            _buildNavButton(
-              context,
-              'Login',
-              Icons.login,
-              Colors.green,
-              () => router.navigate(.parse('/login')),
-            ),
-            const SizedBox(height: 32),
-            const Divider(),
-            const SizedBox(height: 16),
-            const Text(
-              'Declarative Navigation (using Link widget)',
-              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
-            ),
-            const SizedBox(height: 16),
-            Link(
-              to: Uri.parse('/concerts'),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 24,
-                  vertical: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.orange,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: const Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.music_note, color: Colors.white),
-                    SizedBox(width: 8),
-                    Text(
-                      'Concerts',
-                      style: TextStyle(color: Colors.white, fontSize: 16),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.home, size: 80, color: Colors.deepPurple),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Welcome to Unrouter Example',
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 32),
+                  const Text(
+                    'Imperative Navigation (using buttons)',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildNavButton(
+                    context,
+                    'About',
+                    Icons.info,
+                    Colors.blue,
+                    () => context.navigate(.parse('/about')),
+                  ),
+                  _buildNavButton(
+                    context,
+                    'Login',
+                    Icons.login,
+                    Colors.green,
+                    () => router.navigate(.parse('/login')),
+                  ),
+                  const SizedBox(height: 32),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Declarative Navigation (using Link widget)',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 16),
+                  Link(
+                    to: Uri.parse('/concerts'),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.orange,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.music_note, color: Colors.white),
+                          SizedBox(width: 8),
+                          Text(
+                            'Concerts',
+                            style: TextStyle(color: Colors.white, fontSize: 16),
+                          ),
+                        ],
+                      ),
                     ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(height: 12),
+                  Link.builder(
+                    to: Uri.parse('/products'),
+                    builder: (context, location, navigate) {
+                      return Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 12,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.purple,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: InkWell(
+                          onTap: () => navigate(),
+                          child: const Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(Icons.shopping_bag, color: Colors.white),
+                              SizedBox(width: 8),
+                              Text(
+                                'Products (Link.builder)',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Navigator 1.0 APIs (enabled by default)',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildNavButton(
+                    context,
+                    'Show Dialog',
+                    Icons.chat_bubble_outline,
+                    Colors.indigo,
+                    () => _showLegacyDialog(context),
+                  ),
+                  _buildNavButton(
+                    context,
+                    'Show Bottom Sheet',
+                    Icons.keyboard_arrow_up,
+                    Colors.teal,
+                    () => _showLegacyBottomSheet(context),
+                  ),
+                  _buildNavButton(
+                    context,
+                    'Show Menu',
+                    Icons.more_vert,
+                    Colors.brown,
+                    () => _showLegacyMenu(context),
+                  ),
+                  _buildNavButton(
+                    context,
+                    'Push Page',
+                    Icons.open_in_new,
+                    Colors.deepPurple,
+                    () => _pushLegacyPage(context),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(height: 12),
-            Link.builder(
-              to: Uri.parse('/products'),
-              builder: (context, location, navigate) {
-                return Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 12,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.purple,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: InkWell(
-                    onTap: () => navigate(),
-                    child: const Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.shopping_bag, color: Colors.white),
-                        SizedBox(width: 8),
-                        Text(
-                          'Products (Link.builder)',
-                          style: TextStyle(color: Colors.white, fontSize: 16),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
-          ],
+          ),
         ),
       ),
     );
@@ -184,6 +232,79 @@ class Home extends StatelessWidget {
           minimumSize: const Size(200, 50),
         ),
       ),
+    );
+  }
+
+  void _showLegacyDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Dialog'),
+          content: const Text(
+            'This dialog uses Navigator 1.0 APIs inside Unrouter.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showLegacyBottomSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Bottom Sheet',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 12),
+                const Text('This bottom sheet is Navigator 1.0 based.'),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Close'),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showLegacyMenu(BuildContext context) {
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final position = RelativeRect.fromLTRB(
+      24,
+      24,
+      overlay.size.width - 24,
+      overlay.size.height - 24,
+    );
+    showMenu<String>(
+      context: context,
+      position: position,
+      items: const [
+        PopupMenuItem<String>(value: 'first', child: Text('Menu Item A')),
+        PopupMenuItem<String>(value: 'second', child: Text('Menu Item B')),
+      ],
+    );
+  }
+
+  void _pushLegacyPage(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (context) => const LegacyDetailsPage()),
     );
   }
 }
@@ -225,6 +346,36 @@ class About extends StatelessWidget {
             ElevatedButton(
               onPressed: () => context.navigate(.parse('/')),
               child: const Text('Back to Home'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class LegacyDetailsPage extends StatelessWidget {
+  const LegacyDetailsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Navigator 1.0 Page')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.open_in_new, size: 80, color: Colors.deepPurple),
+            const SizedBox(height: 24),
+            const Text(
+              'Pushed with Navigator.of(context).push',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Pop'),
             ),
           ],
         ),

--- a/test/navigator1_support_test.dart
+++ b/test/navigator1_support_test.dart
@@ -1,0 +1,578 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unrouter/unrouter.dart';
+
+void main() {
+  Widget wrap(Unrouter router) {
+    return MaterialApp.router(routerConfig: router);
+  }
+
+  testWidgets('showDialog works with default navigator 1 support', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _DialogPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    expect(find.text('Open'), findsOneWidget);
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dialog'), findsOneWidget);
+  });
+
+  testWidgets('showModalBottomSheet works with navigator 1 support', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _BottomSheetPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    expect(find.text('Open Sheet'), findsOneWidget);
+    await tester.tap(find.text('Open Sheet'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sheet'), findsOneWidget);
+    await tester.tap(find.text('Close Sheet'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sheet'), findsNothing);
+  });
+
+  testWidgets('Navigator.push and pop work with navigator 1 support', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _PushPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    expect(find.text('Push'), findsOneWidget);
+    await tester.tap(find.text('Push'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pushed'), findsOneWidget);
+    await tester.tap(find.text('Pop'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pushed'), findsNothing);
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('showGeneralDialog works with navigator 1 support', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _GeneralDialogPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    await tester.tap(find.text('Open General'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('General Dialog'), findsOneWidget);
+    await tester.tap(find.text('Close General'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('General Dialog'), findsNothing);
+  });
+
+  testWidgets('showMenu works with navigator 1 support', (tester) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _MenuPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    await tester.tap(find.text('Open Menu'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Menu Item'), findsOneWidget);
+    await tester.tap(find.text('Menu Item'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Menu Item'), findsNothing);
+  });
+
+  testWidgets('popRoute closes dialog before history navigation', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [
+        Inlet(factory: () => const _DialogPage(label: 'Home')),
+        Inlet(
+          path: 'about',
+          factory: () => const _DialogPage(label: 'About'),
+        ),
+      ],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    router.navigate(.parse('/about'));
+    await tester.pumpAndSettle();
+    expect(find.text('About'), findsOneWidget);
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Dialog'), findsOneWidget);
+
+    await router.routerDelegate.popRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('Dialog'), findsNothing);
+    expect(find.text('About'), findsOneWidget);
+
+    await router.routerDelegate.popRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('popRoute closes pushed route before history navigation', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [
+        Inlet(factory: () => const _PushPage(label: 'Home')),
+        Inlet(
+          path: 'about',
+          factory: () => const _PushPage(label: 'About'),
+        ),
+      ],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    router.navigate(.parse('/about'));
+    await tester.pumpAndSettle();
+    expect(find.text('About'), findsOneWidget);
+
+    await tester.tap(find.text('Push'));
+    await tester.pumpAndSettle();
+    expect(find.text('Pushed'), findsOneWidget);
+
+    await router.routerDelegate.popRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('Pushed'), findsNothing);
+    expect(find.text('About'), findsOneWidget);
+
+    await router.routerDelegate.popRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('Navigator.popUntil pops to first', (tester) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _PushPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    await tester.tap(find.text('Push'));
+    await tester.pumpAndSettle();
+    expect(find.text('Pushed'), findsOneWidget);
+
+    await tester.tap(find.text('Push Deeper'));
+    await tester.pumpAndSettle();
+    expect(find.text('Pushed Deep'), findsOneWidget);
+
+    await tester.tap(find.text('Pop Until Root'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pushed Deep'), findsNothing);
+    expect(find.text('Pushed'), findsNothing);
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('nested Navigator uses inner stack independently', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _NestedNavigatorPage(label: 'Home'))],
+      history: MemoryHistory(),
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    expect(find.text('Inner Home'), findsOneWidget);
+    await tester.tap(find.text('Inner Push'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Inner Pushed'), findsOneWidget);
+    await tester.tap(find.text('Inner Pop'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Inner Pushed'), findsNothing);
+    expect(find.text('Inner Home'), findsOneWidget);
+  });
+
+  testWidgets('disable navigator 1 support keeps previous behavior', (
+    tester,
+  ) async {
+    final router = Unrouter(
+      routes: [Inlet(factory: () => const _DialogPage(label: 'Home'))],
+      history: MemoryHistory(),
+      enableNavigator1: false,
+    );
+
+    await tester.pumpWidget(wrap(router));
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    final exception = tester.takeException();
+    expect(exception, isA<FlutterError>());
+  });
+}
+
+class _DialogPage extends StatelessWidget {
+  const _DialogPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {
+              showDialog<void>(
+                context: context,
+                builder: (context) {
+                  return const AlertDialog(content: Text('Dialog'));
+                },
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BottomSheetPage extends StatelessWidget {
+  const _BottomSheetPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) {
+                    return SizedBox(
+                      height: 200,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Sheet'),
+                          const SizedBox(height: 8),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('Close Sheet'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+              child: const Text('Open Sheet'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PushPage extends StatelessWidget {
+  const _PushPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (context) => const _PushedPage(),
+                  ),
+                );
+              },
+              child: const Text('Push'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PushedPage extends StatelessWidget {
+  const _PushedPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Pushed'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (context) => const _PushedDeepPage(),
+                  ),
+                );
+              },
+              child: const Text('Push Deeper'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              },
+              child: const Text('Pop Until Root'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Pop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PushedDeepPage extends StatelessWidget {
+  const _PushedDeepPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Pushed Deep'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              },
+              child: const Text('Pop Until Root'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Pop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GeneralDialogPage extends StatelessWidget {
+  const _GeneralDialogPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                showGeneralDialog<void>(
+                  context: context,
+                  barrierDismissible: true,
+                  barrierLabel: 'General',
+                  transitionDuration: const Duration(milliseconds: 1),
+                  pageBuilder: (context, animation, secondaryAnimation) {
+                    return Center(
+                      child: Material(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Text('General Dialog'),
+                              const SizedBox(height: 8),
+                              TextButton(
+                                onPressed: () => Navigator.of(context).pop(),
+                                child: const Text('Close General'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+              child: const Text('Open General'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuPage extends StatelessWidget {
+  const _MenuPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                showMenu<void>(
+                  context: context,
+                  position: const RelativeRect.fromLTRB(20, 20, 20, 20),
+                  items: const [
+                    PopupMenuItem<void>(value: null, child: Text('Menu Item')),
+                  ],
+                );
+              },
+              child: const Text('Open Menu'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NestedNavigatorPage extends StatelessWidget {
+  const _NestedNavigatorPage({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(label),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 200,
+            child: Navigator(
+              onGenerateRoute: (settings) {
+                return MaterialPageRoute<void>(
+                  builder: (context) => const _InnerHomePage(),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InnerHomePage extends StatelessWidget {
+  const _InnerHomePage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('Inner Home'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (context) => const _InnerPushedPage(),
+                ),
+              );
+            },
+            child: const Text('Inner Push'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InnerPushedPage extends StatelessWidget {
+  const _InnerPushedPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('Inner Pushed'),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Inner Pop'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `enableNavigator1` (default true) with an embedded Navigator 1.0 host
- delegate `popRoute` to Navigator overlays before history navigation
- add comprehensive Navigator 1.0 widget tests (dialogs, menus, bottom sheets, push/pop/popUntil, nested Navigator)
- update example app to demonstrate Navigator 1.0 APIs
- add `AGENTS.md` contributor guide and 0.3.0-wip changelog entry

## Testing
- flutter test

Resolves #10
