### PR TITLE
feat!: remove Link.builder constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.4.0 (Unreleased)
 
+### Breaking Changes
+
+- `Link.builder` constructor removed. Use `Link(builder: ...)` and provide
+  either `child` or `builder` (not both).
+
 ### Features
 
 - **Navigation guards**: add `guards` and `maxRedirects` to intercept navigation

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Link(
 Custom link with builder:
 
 ```dart
-Link.builder(
+Link(
   to: Uri.parse('/products/1'),
   state: {'source': 'home'},
   builder: (context, location, navigate) {

--- a/lib/src/widgets/link.dart
+++ b/lib/src/widgets/link.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import '../navigation.dart';
 
-/// Signature for the builder callback used by [Link.builder].
+/// Signature for the builder callback used by `Link(builder: ...)`.
 ///
 /// The [location] parameter provides the target route information.
 /// The [navigate] callback can be called to trigger navigation with optional overrides.
@@ -27,9 +27,9 @@ typedef LinkBuilder =
 /// )
 /// ```
 ///
-/// For more control, use [Link.builder]:
+/// For more control, use `builder`:
 /// ```dart
-/// Link.builder(
+/// Link(
 ///   to: Uri.parse('/products/1'),
 ///   state: {'source': 'homepage'},
 ///   builder: (context, location, navigate) {
@@ -49,27 +49,15 @@ class Link extends StatelessWidget {
   const Link({
     super.key,
     required this.to,
-    required this.child,
+    this.child,
+    this.builder,
     this.replace = false,
     this.state,
-  }) : builder = null;
-
-  /// Creates a link with a custom builder.
-  ///
-  /// The [builder] callback receives:
-  /// - [context]: The build context
-  /// - [location]: A [RouteInformation] containing [to] and [state]
-  /// - [navigate]: A function to trigger navigation with optional overrides
-  ///
-  /// This constructor gives you full control over the widget structure and
-  /// gesture handling.
-  const Link.builder({
-    super.key,
-    required this.to,
-    required LinkBuilder this.builder,
-    this.replace = false,
-    this.state,
-  }) : child = null;
+  }) : assert(child != null || builder != null, 'Provide a child or builder.'),
+       assert(
+         child == null || builder == null,
+         'Provide either child or builder, not both.',
+       );
 
   /// The target URI to navigate to.
   final Uri to;
@@ -86,12 +74,12 @@ class Link extends StatelessWidget {
 
   /// The widget to display for the link.
   ///
-  /// Only used when creating a [Link] with the default constructor.
+  /// Only used when [builder] is null.
   final Widget? child;
 
   /// The builder function for custom link rendering.
   ///
-  /// Only used when creating a [Link.builder].
+  /// Only used when [child] is null.
   final LinkBuilder? builder;
 
   @override

--- a/test/link_widget_test.dart
+++ b/test/link_widget_test.dart
@@ -85,7 +85,7 @@ void main() {
       expect(capturedState, equals({'source': 'home'}));
     });
 
-    testWidgets('Link.builder provides location and navigate callback', (
+    testWidgets('Link builder provides location and navigate callback', (
       tester,
     ) async {
       final router = Unrouter(
@@ -109,7 +109,7 @@ void main() {
       expect(find.text('Target Page'), findsOneWidget);
     });
 
-    testWidgets('Link.builder navigate callback supports overrides', (
+    testWidgets('Link builder navigate callback supports overrides', (
       tester,
     ) async {
       final router = Unrouter(
@@ -256,7 +256,7 @@ class BuilderTestPage extends StatelessWidget {
       body: Column(
         children: [
           const Text('Builder Test'),
-          Link.builder(
+          Link(
             to: Uri.parse('/target'),
             state: 'test-state',
             builder: (context, location, navigate) {
@@ -287,7 +287,7 @@ class OverrideTestPage extends StatelessWidget {
       body: Column(
         children: [
           const Text('Override Test'),
-          Link.builder(
+          Link(
             to: Uri.parse('/page1'),
             builder: (context, location, navigate) {
               return GestureDetector(
@@ -311,7 +311,7 @@ class Page1 extends StatelessWidget {
       body: Column(
         children: [
           const Text('Page 1'),
-          Link.builder(
+          Link(
             to: Uri.parse('/page2'),
             replace: false,
             builder: (context, location, navigate) {


### PR DESCRIPTION
## Summary
- remove Link.builder and support builder via Link(...) constructor
- add assert for child/builder mutual exclusivity
- update docs and tests
- document breaking change in CHANGELOG

## Tests
- flutter test test/link_widget_test.dart -r expanded