### PR TITLE
feat!: async navigation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `Link.builder` constructor removed. Use `Link(builder: ...)` and provide
   either `child` or `builder` (not both).
+- `Navigate` methods now return `Future<Navigation>`; await when you need to
+  know whether navigation succeeded, redirected, or was cancelled.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All sections below are collapsible. Expand the chapters you need.
 - Nested routes + layouts (`Outlet` for declarative routes, `Routes` for widget-scoped)
 - URL patterns: static, params (`:id`), optionals (`?`), wildcard (`*`)
 - Browser-style navigation: push/replace/back/forward/go
+- Async navigation results via `Navigation` (awaitable)
 - Navigation guards with allow/cancel/redirect
 - Navigator 1.0 compatibility for overlays and imperative APIs (`enableNavigator1`, default `true`)
 - Web URL strategies: `UrlStrategy.browser` and `UrlStrategy.hash`
@@ -226,6 +227,18 @@ router.navigate.forward();
 router.navigate.go(-1);
 ```
 
+### Navigation results
+
+All navigation methods return `Future<Navigation>`. You can ignore the result
+or await it when you need to know what happened.
+
+```dart
+final result = await router.navigate(.parse('/about'));
+if (result case NavigationRedirected()) {
+  // handle redirects
+}
+```
+
 ### Navigation from any widget
 
 ```dart
@@ -408,6 +421,7 @@ flutter test
 - `Outlet`: renders the next matched child route (declarative routes)
 - `Routes`: widget-scoped route matcher
 - `Navigate`: navigation interface (`Navigate.of(context)`)
+- `Navigation`: async result returned by navigation methods
 - `Guard` / `GuardResult`: navigation interception and redirects
 - `RouterStateProvider`: read `RouteInformation` + merged params
 - `History` / `MemoryHistory`: injectable history (great for tests)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -156,7 +156,7 @@ class Home extends StatelessWidget {
                               Icon(Icons.shopping_bag, color: Colors.white),
                               SizedBox(width: 8),
                               Text(
-                                'Products (Link.builder)',
+                                'Products (Link builder)',
                                 style: TextStyle(
                                   color: Colors.white,
                                   fontSize: 16,

--- a/lib/src/navigation_result.dart
+++ b/lib/src/navigation_result.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'history/history.dart';
+
+@immutable
+sealed class Navigation {
+  const Navigation({required this.from, required this.requested});
+
+  final RouteInformation from;
+  final RouteInformation requested;
+}
+
+final class NavigationSuccess extends Navigation {
+  const NavigationSuccess({
+    required super.from,
+    required super.requested,
+    required this.to,
+    required this.action,
+    this.redirectCount = 0,
+  });
+
+  final RouteInformation to;
+  final HistoryAction action;
+  final int redirectCount;
+}
+
+final class NavigationRedirected extends NavigationSuccess {
+  const NavigationRedirected({
+    required super.from,
+    required super.requested,
+    required super.to,
+    required super.action,
+    required super.redirectCount,
+  });
+}
+
+final class NavigationCancelled extends Navigation {
+  const NavigationCancelled({required super.from, required super.requested});
+}
+
+final class NavigationFailed extends Navigation {
+  const NavigationFailed({
+    required super.from,
+    required super.requested,
+    required this.error,
+    this.stackTrace,
+  });
+
+  final Object error;
+  final StackTrace? stackTrace;
+}

--- a/lib/src/widgets/link.dart
+++ b/lib/src/widgets/link.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/widgets.dart';
 
 import '../navigation.dart';
+import '../navigation_result.dart';
 
 /// Signature for the builder callback used by `Link(builder: ...)`.
 ///
 /// The [location] parameter provides the target route information.
-/// The [navigate] callback can be called to trigger navigation with optional overrides.
+/// The [navigate] callback can be called to trigger navigation with optional
+/// overrides and returns a `Future<Navigation>`.
 typedef LinkBuilder =
     Widget Function(
       BuildContext context,
       RouteInformation location,
-      void Function({Object? state, bool? replace}) navigate,
+      Future<Navigation> Function({Object? state, bool? replace}) navigate,
     );
 
 /// A widget that navigates to a specified route when tapped.
@@ -84,8 +86,8 @@ class Link extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    void navigate({Object? state, bool? replace}) {
-      context.navigate(
+    Future<Navigation> navigate({Object? state, bool? replace}) {
+      return context.navigate(
         to,
         state: state ?? this.state,
         replace: replace ?? this.replace,

--- a/lib/unrouter.dart
+++ b/lib/unrouter.dart
@@ -37,6 +37,7 @@ export 'src/widgets/routes.dart';
 export 'src/guard.dart';
 export 'src/inlet.dart';
 export 'src/navigation.dart';
+export 'src/navigation_result.dart';
 export 'src/route_matcher.dart' show MatchedRoute;
 export 'src/router.dart';
 export 'src/router_state.dart';

--- a/test/guard_test.dart
+++ b/test/guard_test.dart
@@ -35,10 +35,13 @@ void main() {
     await tester.pumpWidget(wrap(router));
     expect(find.text('Home'), findsOneWidget);
 
-    router.navigate(.parse('/login'));
+    final result = await router.navigate(.parse('/login'));
     await pumpGuards(tester);
 
     expect(called, isTrue);
+    expect(result, isA<NavigationSuccess>());
+    final success = result as NavigationSuccess;
+    expect(success.action, HistoryAction.push);
     expect(find.text('Login'), findsOneWidget);
     expect(router.history.location.uri.path, '/login');
   });
@@ -56,11 +59,12 @@ void main() {
     await tester.pumpWidget(wrap(router));
     expect(find.text('Home'), findsOneWidget);
 
-    router.navigate(.parse('/login'));
+    final result = await router.navigate(.parse('/login'));
     await pumpGuards(tester);
 
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
+    expect(result, isA<NavigationCancelled>());
     expect(router.history.location.uri.path, '/');
     expect(router.history.index, 0);
   });
@@ -88,11 +92,12 @@ void main() {
 
     await tester.pumpWidget(wrap(router));
 
-    router.navigate(.parse('/login'));
+    final result = await router.navigate(.parse('/login'));
     await pumpGuards(tester);
 
     expect(firstCalled, isTrue);
     expect(secondCalled, isFalse);
+    expect(result, isA<NavigationCancelled>());
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
     expect(router.history.location.uri.path, '/');
@@ -111,15 +116,17 @@ void main() {
 
     await tester.pumpWidget(wrap(router));
 
-    router.navigate(.parse('/login'));
+    final navigation = router.navigate(.parse('/login'));
     await tester.pump();
 
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
 
     completer.complete(GuardResult.allow);
+    final result = await navigation;
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationSuccess>());
     expect(find.text('Login'), findsOneWidget);
     expect(router.history.location.uri.path, '/login');
   });
@@ -140,9 +147,10 @@ void main() {
 
     await tester.pumpWidget(wrap(router));
 
-    router.navigate(.parse('/login'));
+    final result = await router.navigate(.parse('/login'));
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationCancelled>());
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
     expect(router.history.location.uri.path, '/');
@@ -166,19 +174,13 @@ void main() {
     );
 
     await tester.pumpWidget(wrap(router));
-    Object? captured;
 
-    await runZonedGuarded(
-      () async {
-        router.navigate(.parse('/login'));
-        await pumpGuards(tester);
-      },
-      (error, stack) {
-        captured = error;
-      },
-    );
+    final result = await router.navigate(.parse('/login'));
+    await pumpGuards(tester);
 
-    expect(captured, isA<StateError>());
+    expect(result, isA<NavigationFailed>());
+    final failed = result as NavigationFailed;
+    expect(failed.error, isA<StateError>());
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
     expect(router.history.location.uri.path, '/');
@@ -196,9 +198,12 @@ void main() {
     );
 
     await tester.pumpWidget(wrap(router));
-    router.navigate(.parse('/register'));
+    final result = await router.navigate(.parse('/register'));
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationRedirected>());
+    final redirected = result as NavigationRedirected;
+    expect(redirected.action, HistoryAction.replace);
     expect(find.text('Login'), findsOneWidget);
     expect(find.text('Register'), findsNothing);
     expect(router.history.location.uri.path, '/login');
@@ -216,9 +221,12 @@ void main() {
     );
 
     await tester.pumpWidget(wrap(router));
-    router.navigate(.parse('/login'), replace: true);
+    final result = await router.navigate(.parse('/login'), replace: true);
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationSuccess>());
+    final success = result as NavigationSuccess;
+    expect(success.action, HistoryAction.replace);
     expect(find.text('Login'), findsOneWidget);
     expect(router.history.location.uri.path, '/login');
     expect(router.history.index, 0);
@@ -243,9 +251,12 @@ void main() {
     );
 
     await tester.pumpWidget(wrap(router));
-    router.navigate(.parse('/register'));
+    final result = await router.navigate(.parse('/register'));
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationRedirected>());
+    final redirected = result as NavigationRedirected;
+    expect(redirected.action, HistoryAction.push);
     expect(find.text('Login'), findsOneWidget);
     expect(router.history.location.uri.path, '/login');
     expect(router.history.index, 1);
@@ -361,9 +372,10 @@ void main() {
     await pumpGuards(tester);
     expect(find.text('Register'), findsOneWidget);
 
-    router.navigate.back();
+    final result = await router.navigate.back();
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationCancelled>());
     expect(find.text('Register'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
     expect(router.history.location.uri.path, '/register');
@@ -399,9 +411,10 @@ void main() {
     await tester.pumpWidget(wrap(router));
     expect(find.text('Register'), findsOneWidget);
 
-    router.navigate.back();
+    final result = await router.navigate.back();
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationCancelled>());
     expect(find.text('Register'), findsOneWidget);
     expect(find.text('Login'), findsNothing);
     expect(router.history.location.uri.path, '/register');
@@ -434,9 +447,12 @@ void main() {
     await pumpGuards(tester);
     expect(find.text('Register'), findsOneWidget);
 
-    router.navigate.back();
+    final result = await router.navigate.back();
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationRedirected>());
+    final redirected = result as NavigationRedirected;
+    expect(redirected.action, HistoryAction.replace);
     expect(find.text('Blocked'), findsOneWidget);
     expect(router.history.location.uri.path, '/blocked');
     expect(router.history.index, 0);
@@ -458,9 +474,10 @@ void main() {
     );
 
     await tester.pumpWidget(wrap(router));
-    router.navigate(.parse('/a'));
+    final result = await router.navigate(.parse('/a'));
     await pumpGuards(tester);
 
+    expect(result, isA<NavigationCancelled>());
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('A'), findsNothing);
     expect(find.text('B'), findsNothing);

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -28,9 +28,12 @@ void main() {
       expect(find.text('About'), findsNothing);
 
       // Navigate to about
-      router.navigate(.parse('/about'));
+      final result = await router.navigate(.parse('/about'));
       await tester.pumpAndSettle();
 
+      expect(result, isA<NavigationSuccess>());
+      final success = result as NavigationSuccess;
+      expect(success.action, HistoryAction.push);
       expect(find.text('Home'), findsNothing);
       expect(find.text('About'), findsOneWidget);
     });
@@ -78,12 +81,15 @@ void main() {
 
       await tester.pumpWidget(wrapRouter(router));
 
-      router.navigate(.parse('/about'));
+      await router.navigate(.parse('/about'));
       await tester.pumpAndSettle();
       expect(find.text('About'), findsOneWidget);
 
-      router.navigate.back();
+      final result = await router.navigate.back();
       await tester.pumpAndSettle();
+      expect(result, isA<NavigationSuccess>());
+      final success = result as NavigationSuccess;
+      expect(success.action, HistoryAction.pop);
       expect(find.text('Home'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
- make Navigate methods return Future<Navigation> results
- add Navigation result types and guard integration for success/redirect/cancel/fail
- update Link builder callback, docs, and example label
- expand tests to assert navigation results

## Tests
- flutter test

Resolves #16