### PR TITLE
Add route-level guards to Inlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - **Navigation guards**: add `guards` and `maxRedirects` to intercept navigation
   (`allow`, `cancel`, `redirect`) across push/replace/pop and external route updates.
+- **Route-level guards**: allow `Inlet.guards` to run per-route guards from
+  root to leaf after global guards.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,23 @@ final router = Unrouter(
 );
 ```
 
+You can also attach guards to specific declarative routes:
+
+```dart
+final routes = [
+  Inlet(
+    path: 'admin',
+    guards: [
+      (context) => GuardResult.redirect(Uri.parse('/login')),
+    ],
+    factory: AdminPage.new,
+  ),
+];
+```
+
+Guards run in order: global guards first, then matched route guards from root
+to leaf. The first non-allow result (cancel/redirect) short-circuits.
+
 Guards receive a `GuardContext`:
 - `to`: target `RouteInformation`
 - `from`: previous `RouteInformation`

--- a/lib/src/router/inlet.dart
+++ b/lib/src/router/inlet.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 
+import 'guard.dart';
+
 /// A route configuration that defines a path pattern and widget factory.
 ///
 /// The semantics are based on [path] and [children]:
@@ -44,12 +46,19 @@ class Inlet {
   /// Factory function that creates the widget for this route.
   final Widget Function() factory;
 
+  /// Guards that run when navigating to this route.
+  ///
+  /// Guards run after global guards and follow the matched route stack
+  /// from root to leaf.
+  final List<Guard> guards;
+
   /// Child routes.
   final List<Inlet> children;
 
   const Inlet({
     this.path = '',
     required this.factory,
+    this.guards = const [],
     this.children = const [],
   });
 

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -227,7 +227,10 @@ class UnrouterDelegate extends RouterDelegate<RouteInformation>
       }
 
       router.guard
-          .execute(guardContext)
+          .execute(
+            guardContext,
+            extraGuards: _resolveRouteGuards(requested),
+          )
           .then((context) {
             if (context == null) {
               handleCancel();
@@ -353,6 +356,16 @@ class UnrouterDelegate extends RouterDelegate<RouteInformation>
     );
   }
 
+  Iterable<Guard> _resolveRouteGuards(RouteInformation routeInformation) {
+    final routeList = routes;
+    if (routeList == null) return const [];
+    final result = matchRoutes(routeList, routeInformation.uri.path);
+    if (result.matches.isEmpty) return const [];
+    return [
+      for (final match in result.matches) ...match.route.guards,
+    ];
+  }
+
   /// Update matched routes based on current location.
   void _updateMatchedRoutes() {
     if (routes == null) {
@@ -388,7 +401,10 @@ class UnrouterDelegate extends RouterDelegate<RouteInformation>
       redirectCount: 0,
     );
 
-    final resolved = await router.guard.execute(context);
+    final resolved = await router.guard.execute(
+      context,
+      extraGuards: _resolveRouteGuards(configuration),
+    );
     if (resolved == null) {
       return;
     }
@@ -483,7 +499,10 @@ class UnrouterDelegate extends RouterDelegate<RouteInformation>
       redirectCount: 0,
     );
     try {
-      final resolved = await router.guard.execute(context);
+      final resolved = await router.guard.execute(
+        context,
+        extraGuards: _resolveRouteGuards(requested),
+      );
       if (resolved == null) {
         return NavigationCancelled(from: previous, requested: requested);
       }


### PR DESCRIPTION
## Summary
- add route-level guards via `Inlet.guards` and run them after global guards
- short-circuit guards on cancel/redirect; respect maxRedirects
- update docs, tests, and changelog

## Testing
- flutter test test/guard_test.dart
- flutter test

Fixes #14
