### PR TITLE
Add granular route state accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   root to leaf after global guards.
 - **Route animations**: add `context.routeAnimation(...)` to access per-route
   animation controllers for push/replace/pop transitions.
+- **Granular route state accessors**: add `context.location`,
+  `context.matchedRoutes`, `context.routeLevel`, `context.historyIndex`,
+  and `context.historyAction` for fine-grained rebuilds.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,16 @@ final params = state.params;        // merged params up to this level
 final extra = state.location.state; // history entry state (if any)
 ```
 
+You can also read fine-grained fields (with narrower rebuild scopes):
+
+```dart
+final location = context.location;
+final matched = context.matchedRoutes;
+final level = context.routeLevel;
+final index = context.historyIndex;
+final action = context.historyAction;
+```
+
 `RouteState.action` tells you whether the current navigation was a push,
 replace, or pop, and `historyIndex` can be used to reason about stacked pages.
 
@@ -467,7 +477,7 @@ flutter test
 - `Navigate`: navigation interface (`context.navigate`)
 - `Navigation`: async result returned by navigation methods
 - `Guard` / `GuardResult`: navigation interception and redirects
-- `RouteStateScope`: internal provider (read via `context.routeState`)
+- `RouteState`: current route state (read via `context.routeState`)
 - `History` / `MemoryHistory`: injectable history (great for tests)
 - `Link`: declarative navigation widget
 
@@ -493,8 +503,7 @@ flutter run
 
 - `context.navigate` throws: ensure your widget is under an `Unrouter` router
   (either `MaterialApp.router(routerConfig: Unrouter(...))` or `runApp(Unrouter(...))`).
-- `Routes` renders nothing: it must be a descendant of `Unrouter`
-  (needs a `RouteStateScope`).
+- `Routes` renders nothing: it must be a descendant of `Unrouter`.
 - `showDialog` not working: keep `enableNavigator1: true` (default).
 - Web 404 on refresh: use `strategy: .hash` or configure server rewrites.
 

--- a/lib/src/router/_internal/route_state_scope.dart
+++ b/lib/src/router/_internal/route_state_scope.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/widgets.dart';
+import 'package:unrouter/history.dart';
+
+import '../route_matcher.dart';
+import '../route_state.dart';
+
+enum RouteStateAspect { location, matchedRoutes, level, historyIndex, action }
+
+class RouteStateScope extends InheritedModel<RouteStateAspect> {
+  const RouteStateScope({super.key, required this.state, required super.child});
+
+  final RouteState state;
+
+  static RouteStateScope? maybeOf(
+    BuildContext context, {
+    RouteStateAspect? aspect,
+  }) {
+    return InheritedModel.inheritFrom<RouteStateScope>(context, aspect: aspect);
+  }
+
+  static RouteStateScope? maybeOfAll(BuildContext context) {
+    RouteStateScope? scope;
+    for (final aspect in RouteStateAspect.values) {
+      scope = maybeOf(context, aspect: aspect) ?? scope;
+    }
+    return scope;
+  }
+
+  @override
+  bool updateShouldNotify(RouteStateScope oldWidget) {
+    return state != oldWidget.state;
+  }
+
+  @override
+  bool updateShouldNotifyDependent(
+    RouteStateScope oldWidget,
+    Set<RouteStateAspect> aspects,
+  ) {
+    final current = state;
+    final previous = oldWidget.state;
+
+    for (final aspect in aspects) {
+      switch (aspect) {
+        case RouteStateAspect.location:
+          if (!_sameLocation(previous.location, current.location)) {
+            return true;
+          }
+          break;
+        case RouteStateAspect.matchedRoutes:
+          if (!_sameMatchedRoutes(
+            previous.matchedRoutes,
+            current.matchedRoutes,
+          )) {
+            return true;
+          }
+          break;
+        case RouteStateAspect.level:
+          if (previous.level != current.level) {
+            return true;
+          }
+          break;
+        case RouteStateAspect.historyIndex:
+          if (previous.historyIndex != current.historyIndex) {
+            return true;
+          }
+          break;
+        case RouteStateAspect.action:
+          if (previous.action != current.action) {
+            return true;
+          }
+          break;
+      }
+    }
+
+    return false;
+  }
+
+  bool _sameLocation(RouteInformation a, RouteInformation b) {
+    return a.uri == b.uri && a.state == b.state;
+  }
+
+  bool _sameMatchedRoutes(List<MatchedRoute> a, List<MatchedRoute> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      final left = a[i];
+      final right = b[i];
+      if (!identical(left.route, right.route)) return false;
+      if (!_sameParams(left.params, right.params)) return false;
+    }
+    return true;
+  }
+
+  bool _sameParams(Map<String, String> a, Map<String, String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  RouteInformation get location => state.location;
+  List<MatchedRoute> get matchedRoutes => state.matchedRoutes;
+  int get level => state.level;
+  int get historyIndex => state.historyIndex;
+  HistoryAction get action => state.action;
+}

--- a/lib/src/router/_internal/stacked_route_view.dart
+++ b/lib/src/router/_internal/stacked_route_view.dart
@@ -6,6 +6,7 @@ import 'package:unrouter/history.dart';
 import '../inlet.dart';
 import 'route_animation.dart';
 import '../route_state.dart';
+import 'route_state_scope.dart';
 import 'route_cache_key.dart';
 
 /// Renders a matched route and keeps a stack of pages.

--- a/lib/src/router/extensions.dart
+++ b/lib/src/router/extensions.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/widgets.dart';
 
+import 'package:unrouter/history.dart';
+
 import 'navigation.dart';
 import 'router.dart';
 import '_internal/route_animation.dart';
+import '_internal/route_state_scope.dart';
+import 'route_matcher.dart';
 import 'route_state.dart';
 
 extension UnrouterBuildContext on BuildContext {
@@ -53,7 +57,7 @@ extension UnrouterBuildContext on BuildContext {
   }
 
   RouteState get routeState {
-    final provider = dependOnInheritedWidgetOfExactType<RouteStateScope>();
+    final provider = RouteStateScope.maybeOfAll(this);
     assert(
       provider != null,
       'No RouteStateScope found in context. '
@@ -62,8 +66,72 @@ extension UnrouterBuildContext on BuildContext {
     return provider!.state;
   }
 
-  RouteState? get maybeRouteState =>
-      dependOnInheritedWidgetOfExactType<RouteStateScope>()?.state;
+  RouteState? get maybeRouteState => RouteStateScope.maybeOfAll(this)?.state;
+
+  RouteInformation get location {
+    final provider = RouteStateScope.maybeOf(
+      this,
+      aspect: RouteStateAspect.location,
+    );
+    assert(
+      provider != null,
+      'No RouteStateScope found in context. '
+      'Make sure your widget is a descendant of Unrouter.',
+    );
+    return provider!.location;
+  }
+
+  List<MatchedRoute> get matchedRoutes {
+    final provider = RouteStateScope.maybeOf(
+      this,
+      aspect: RouteStateAspect.matchedRoutes,
+    );
+    assert(
+      provider != null,
+      'No RouteStateScope found in context. '
+      'Make sure your widget is a descendant of Unrouter.',
+    );
+    return provider!.matchedRoutes;
+  }
+
+  int get routeLevel {
+    final provider = RouteStateScope.maybeOf(
+      this,
+      aspect: RouteStateAspect.level,
+    );
+    assert(
+      provider != null,
+      'No RouteStateScope found in context. '
+      'Make sure your widget is a descendant of Unrouter.',
+    );
+    return provider!.level;
+  }
+
+  int get historyIndex {
+    final provider = RouteStateScope.maybeOf(
+      this,
+      aspect: RouteStateAspect.historyIndex,
+    );
+    assert(
+      provider != null,
+      'No RouteStateScope found in context. '
+      'Make sure your widget is a descendant of Unrouter.',
+    );
+    return provider!.historyIndex;
+  }
+
+  HistoryAction get historyAction {
+    final provider = RouteStateScope.maybeOf(
+      this,
+      aspect: RouteStateAspect.action,
+    );
+    assert(
+      provider != null,
+      'No RouteStateScope found in context. '
+      'Make sure your widget is a descendant of Unrouter.',
+    );
+    return provider!.action;
+  }
 
   AnimationController routeAnimation({
     double? value,

--- a/lib/src/router/route_state.dart
+++ b/lib/src/router/route_state.dart
@@ -5,7 +5,6 @@ import 'route_matcher.dart';
 
 /// Route state that flows through the widget tree.
 ///
-/// `unrouter` provides this state to every routed widget via [RouteStateScope].
 /// It contains the current [RouteInformation], the matched route stack, and the
 /// current rendering [level] for nested routing.
 class RouteState {
@@ -88,25 +87,4 @@ class RouteState {
   @override
   String toString() =>
       'RouteState(location: $location, level: $level, matched: ${matchedRoutes.length})';
-}
-
-/// Provides [RouteState] to the widget tree.
-///
-/// You usually don't create this widget yourself; it is inserted by `unrouter`.
-///
-/// ```dart
-/// final state = context.routeState;
-/// final uri = state.location.uri;
-/// final id = state.params['id'];
-/// ```
-class RouteStateScope extends InheritedWidget {
-  const RouteStateScope({super.key, required this.state, required super.child});
-
-  /// The current route state.
-  final RouteState state;
-
-  @override
-  bool updateShouldNotify(RouteStateScope oldWidget) {
-    return state != oldWidget.state;
-  }
 }

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -11,6 +11,7 @@ import 'inlet.dart';
 import 'navigation.dart';
 import 'route_matcher.dart';
 import 'route_state.dart';
+import '_internal/route_state_scope.dart';
 import 'url_strategy.dart';
 
 /// A declarative router configuration for Flutter.
@@ -182,7 +183,7 @@ class _InformationParser extends RouteInformationParser<RouteInformation> {
 /// The delegate:
 /// - Listens to [History] `pop` events and updates [currentConfiguration].
 /// - Matches the current path against declarative [Inlet] routes (if provided).
-/// - Provides [RouteState] to descendants via [RouteStateScope].
+/// - Provides [RouteState] to descendants.
 /// - Renders widget-scoped [child] if declarative routes don't match or if no routes are provided.
 class UnrouterDelegate extends RouterDelegate<RouteInformation>
     with ChangeNotifier

--- a/lib/src/router/widgets/outlet.dart
+++ b/lib/src/router/widgets/outlet.dart
@@ -9,8 +9,7 @@ import '../extensions.dart';
 /// to render their children.
 ///
 /// It keeps child widgets stacked so their state is preserved across
-/// navigation. `Outlet` must be a descendant of `Unrouter` (it relies on
-/// [RouteStateScope]).
+/// navigation. `Outlet` must be a descendant of `Unrouter`.
 ///
 /// For widget-scoped routing, use the [Routes] widget instead.
 class Outlet extends StatelessWidget {


### PR DESCRIPTION
## Summary
- move RouteStateScope to internal InheritedModel with aspect-based notifications
- add context.location/matchedRoutes/routeLevel/historyIndex/historyAction accessors
- update docs and add accessor coverage test

## Testing
- flutter analyze
- flutter test test/context_navigation_test.dart