### PR TITLE
build: prepare release batch unrouter_core 0.2.0 / flutter_unrouter 0.2.1 / nocterm_unrouter 0.3.0 / unrouter 0.14.0

### DIFF
--- a/examples/flutter_example/pubspec.yaml
+++ b/examples/flutter_example/pubspec.yaml
@@ -11,7 +11,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  unrouter: ^0.13.0
+  unrouter: ^0.14.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/nocterm_example/pubspec.yaml
+++ b/examples/nocterm_example/pubspec.yaml
@@ -10,7 +10,7 @@ resolution: workspace
 
 dependencies:
   nocterm: ^0.6.0
-  unrouter: ^0.13.0
+  unrouter: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/flutter_unrouter/CHANGELOG.md
+++ b/packages/flutter_unrouter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1
+
+### What's New
+
+- Internal refactor: extract `_ViewHost` as a shared stateful widget to reduce
+  duplication between the router delegate and outlet rendering paths.
+- Bump `unrouter_core` dependency to `^0.2.0`.
+
 ## v0.2.0
 
 **Migration guide**: See Migration note below.

--- a/packages/flutter_unrouter/pubspec.yaml
+++ b/packages/flutter_unrouter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_unrouter
 description: Declarative nested router for Flutter with guards and Router API integration.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/medz/unrouter
 homepage: https://github.com/medz/unrouter
 issue_tracker: https://github.com/medz/unrouter/issues
@@ -24,7 +24,7 @@ dependencies:
   ht: ^0.3.0
   oref: ^2.8.0
   unstory: ^0.1.1
-  unrouter_core: ^0.1.0
+  unrouter_core: ^0.2.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/packages/nocterm_unrouter/CHANGELOG.md
+++ b/packages/nocterm_unrouter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+### What's New
+
+- Add `useRouter(context)` helper to retrieve the active `Unrouter` instance
+  from the nearest route scope. (#40)
+- Bump `unrouter_core` dependency to `^0.2.0`.
+
 ## v0.2.0
 
 **Migration guide**: See Migration note below.

--- a/packages/nocterm_unrouter/pubspec.yaml
+++ b/packages/nocterm_unrouter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nocterm_unrouter
 description: Declarative nested router for Nocterm apps with guards and nested outlets.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/medz/unrouter
 homepage: https://github.com/medz/unrouter
 issue_tracker: https://github.com/medz/unrouter/issues
@@ -21,7 +21,7 @@ resolution: workspace
 dependencies:
   nocterm: ^0.6.0
   unstory: ^0.1.1
-  unrouter_core: ^0.1.0
+  unrouter_core: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/unrouter/CHANGELOG.md
+++ b/packages/unrouter/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.14.0
+
+### Highlights
+
+Picks up breaking changes from `unrouter_core` 0.2.0, the new `useRouter`
+helper in `nocterm_unrouter` 0.3.0, and the internal `flutter_unrouter` 0.2.1
+refactor.
+
+### Breaking Changes
+
+- `RouteNode.meta` and `RouteRecord.meta` are now non-nullable (`Map<String, Object?>`
+  defaulting to `const {}`). See `unrouter_core` 0.2.0 migration notes.
+- `Unrouter.matcher` and `Unrouter.aliases` expose `roux.Router<T>` which no
+  longer has `.match()`. Use `.find()` instead.
+
+### What's New
+
+- `useRouter(context)` is now available in the `nocterm.dart` entrypoint.
+
+### Migration Notes
+
+- Replace direct calls to `router.matcher.match(path)` with `.find(path)`.
+- Remove `?? const {}` guards on `meta` fields — the value is always non-null.
+
 ## v0.13.0
 
 **Migration guide**: See Migration note below.

--- a/packages/unrouter/pubspec.yaml
+++ b/packages/unrouter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: unrouter
-version: 0.13.0
+version: 0.14.0
 description: Primary Unrouter package with Flutter, Nocterm, and shared core entrypoints.
 repository: https://github.com/medz/unrouter
 homepage: https://github.com/medz/unrouter
@@ -20,10 +20,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  flutter_unrouter: ^0.2.0
-  nocterm_unrouter: ^0.2.0
+  flutter_unrouter: ^0.2.1
+  nocterm_unrouter: ^0.3.0
   unstory: ^0.1.1
-  unrouter_core: ^0.1.0
+  unrouter_core: ^0.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/unrouter_core/CHANGELOG.md
+++ b/packages/unrouter_core/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.2.0
+
+### Highlights
+
+Cleans up the metadata API, fixes a history queue bug, and upgrades the
+underlying path-matching engine to roux 1.0.0.
+
+### Breaking Changes
+
+- `RouteNode.meta` and `RouteRecord.meta` are now `Map<String, Object?>` instead
+  of `Map<String, Object?>?`. Both default to `const {}`. Callers that passed
+  `meta: null` or guarded against `meta == null` must be updated.
+- `Unrouter.aliases` and `Unrouter.matcher` expose `roux.Router<T>`, which no
+  longer has a `.match()` method. Use `.find()` instead.
+
+### What's New
+
+- Upgrade roux to 1.0.0. The router now uses `.find()` for path lookups and
+  per-entry `.add()` for route registration, matching the roux 1.0.0 API.
+  Path matching remains case-sensitive.
+
+### Migration Notes
+
+- Replace any direct calls to `router.matcher.match(path)` or
+  `router.aliases.match(path)` with `.find(path)`.
+- Remove `?? const {}` guards on `RouteNode.meta` and `RouteRecord.meta` — the
+  value is always a non-null map.
+
 ## 0.1.0
 
 - Initial shared routing core package split from the Unrouter workspace.

--- a/packages/unrouter_core/pubspec.yaml
+++ b/packages/unrouter_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unrouter_core
 description: Platform-agnostic routing core for matching, guards, params, and query helpers.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/medz/unrouter
 homepage: https://github.com/medz/unrouter
 issue_tracker: https://github.com/medz/unrouter/issues


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Route metadata (`meta`) is now non-nullable with a default empty map; remove null-checking guards from existing code
  * Router path matching API updated; replace `.match(path)` calls with `.find(path)` for path resolution

* **New Features**
  * Added `useRouter(context)` helper to obtain the active router instance from the current route scope

<!-- end of auto-generated comment: release notes by coderabbit.ai -->